### PR TITLE
[DDO-1397] Pub/sub skeleton

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"github.com/broadinstitute/revere/internal/configuration"
+	"github.com/broadinstitute/revere/internal/pubsub"
+	"github.com/broadinstitute/revere/internal/pubsub/pubsubapi"
+	"github.com/broadinstitute/revere/internal/shared"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"sync"
+)
+
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Continuously translate input events to output communications",
+	Long: `Continuously read input event sources and notify output 
+communication channels as described in the configuration file.
+
+Input event sources:
+	- Google Cloud Monitoring via Google Cloud Pub/Sub`,
+	Run: Serve,
+}
+
+func Serve(*cobra.Command, []string) {
+	config, err := configuration.AssembleConfig(viper.GetViper())
+	cobra.CheckErr(err)
+	client, err := pubsubapi.Client(config)
+	cobra.CheckErr(err)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		shared.LogLn(config, "listening to pubsub...")
+		err = pubsub.ReceiveMessages(config, client)
+		cobra.CheckErr(err)
+		wg.Done()
+	}()
+	wg.Wait()
+}
+
+func init() {
+	rootCmd.AddCommand(serveCmd)
+}

--- a/internal/pubsub/pubsubapi/client.go
+++ b/internal/pubsub/pubsubapi/client.go
@@ -1,0 +1,14 @@
+package pubsubapi
+
+import (
+	"cloud.google.com/go/pubsub"
+	"context"
+	"github.com/broadinstitute/revere/internal/configuration"
+)
+
+// Client within the pubsub package returns the type provided by the Google
+// Pub/Sub client library
+func Client(config *configuration.Config) (*pubsub.Client, error) {
+	client, err := pubsub.NewClient(context.Background(), config.Pubsub.ProjectID)
+	return client, err
+}

--- a/internal/pubsub/receive_messages.go
+++ b/internal/pubsub/receive_messages.go
@@ -1,0 +1,26 @@
+package pubsub
+
+import (
+	"cloud.google.com/go/pubsub"
+	"context"
+	"fmt"
+	"github.com/broadinstitute/revere/internal/configuration"
+)
+
+// receiveOnce should handle and acknowledge a single message; will run
+// asynchronously
+func receiveOnce(config *configuration.Config, msg *pubsub.Message) {
+	fmt.Printf("Message %q from %s", string(msg.Data), config.Pubsub.SubscriptionID)
+	msg.Ack()
+}
+
+// ReceiveMessages should never terminate, it continually pulls messages from
+// the subscription
+func ReceiveMessages(config *configuration.Config, client *pubsub.Client) error {
+	subscription := client.Subscription(config.Pubsub.SubscriptionID)
+	cctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	return subscription.Receive(cctx, func(ctx context.Context, msg *pubsub.Message) {
+		receiveOnce(config, msg)
+	})
+}


### PR DESCRIPTION
The skeleton of "program entrypoint" to "handling one message". The goroutine code runs and it spits out messages as they come in, ctrl+c exits the program reasonably. Seems to be at the place now where I'd start writing code to handle individual messages, so now seems like a good place to solicit review on what I've got.

Tested this by making a pubsub queue and pointing this at it, and shoving messages into the queue. It acknowledges and spits them out, it stops right away if you tell it to, etc. I'm not doing much concurrency right now, but this is running from a goroutine, so anything down the road is, well, down the road.

There's not much I can really unit test here. This is usage of google's pubsub client library, I think maintaining a mock of pubsub's async api or whatever is more trouble than it is worth. I think this particular bit of code is what we'd have to cover with integration tests instead of in-codebase unit tests