### PR TITLE
[DDO-1466] Abuse the linker to embed build version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,7 +65,7 @@ jobs:
           echo ::set-output name=name::${GOOGLE_DOCKER_REPOSITORY}/${GOOGLE_PROJECT}/${REPOSITORY_NAME}/${IMAGE_NAME}:${DOCKER_TAG}
 
       - name: Build image
-        run: "docker build -t ${{ steps.image-name.outputs.name }} ."
+        run: "docker build --build-arg REVERE_BUILD_VERSION=${{ steps.tag.outputs.tag }} -t ${{ steps.image-name.outputs.name }} ."
 
       - name: Run Trivy vulnerability scanner
         # From https://github.com/broadinstitute/dsp-appsec-trivy-action

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,16 @@ ARG GO_VERSION='1.16'
 ARG ALPINE_VERSION='3.14'
 
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} as build
+
+ARG REVERE_BUILD_VERSION='development'
+
 WORKDIR /build
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
 ENV GOBIN=/bin
 COPY . .
-RUN go test ./... && go build -o /bin/ .
+RUN go test ./... && go build -ldflags="-X 'main.BuildVersion=${REVERE_BUILD_VERSION}'" -o /bin/ .
 
 FROM alpine:${ALPINE_VERSION} as runtime
-ENV APP_NAME=revere
-COPY --from=build /bin/${APP_NAME} /bin/${APP_NAME}
-ENTRYPOINT [ "sh", "-c", "/bin/${APP_NAME}" ]
+COPY --from=build /bin/revere /bin/revere
+ENTRYPOINT [ "/bin/revere" ]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,8 @@ func initConfig() {
 	err := viper.ReadInConfig()
 	if err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			cobra.CheckErr(fmt.Errorf("not using a configuration file! %w", err))
+			// Don't error out since "version" command requires no config file
+			fmt.Printf("not using a configuration file! %v\n", err)
 		} else {
 			cobra.CheckErr(err)
 		}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/broadinstitute/revere/internal/version"
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Get Revere's recorded build version",
+	Long: `Get Revere's internal BuildVersion, usually set via LDFlags during
+compilation.'`,
+	Run: func(cmd *cobra.Command, args []string) {
+		println()
+		println("version:")
+		println(version.BuildVersion)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+var BuildVersion = "unknown"

--- a/main.go
+++ b/main.go
@@ -1,7 +1,19 @@
 package main
 
-import "github.com/broadinstitute/revere/cmd"
+import (
+	"github.com/broadinstitute/revere/cmd"
+	"github.com/broadinstitute/revere/internal/version"
+)
+
+// BuildVersion is intended for use with Go's LDFlags compiler option, to
+// set this value at compile time
+var BuildVersion = "development"
 
 func main() {
+	// Short-form LDFlags only work for top-level files, but we can only
+	// import from interior packages later on, so manually set an interior
+	// variable
+	version.BuildVersion = BuildVersion
+
 	cmd.Execute()
 }


### PR DESCRIPTION
Put the version in the binary via the linker. A part of #13 but I wanted to split this out because this is more stable than the other parts in that PR I'm still testing