### PR TITLE
[DDO-1465] Revere alert label reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,3 @@ The configuration file's format is defined by [`internal/config.go`](https://git
 
 Do not manually tag commits. This repository has [Bumper](https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper) enabled, Git tags will be created automatically on merge to `main`. 
 Patch version will be automatically bumped upon merge; including "`#minor`" or "`#major`" in the merge commit body will bump that instead.
-
-Configurations for GoLand/VSCode may (tentatively) be committed, transient components are part of the
-generated `.gitiginore`.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.16
 
 // List direct dependencies (here, not inline, so as to not confuse IDEs):
 // Cobra is a CLI framework facilitating help text, commands, and error checking
+// Genproto provides some pre-built types for handling Google's APIs
 // Gin is the server library
+// Go-Cmp helps diff test results
 // Httpmock works with Resty to mock APIs
 // Mapstructure translates structures based on field names, helpful for API usage
 // Pubsub connects with Google Pub/Sub for input events
@@ -18,7 +20,7 @@ require (
 	github.com/gin-gonic/gin v1.7.4
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/go-cmp v0.5.6
 	github.com/jarcoal/httpmock v1.0.8
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mitchellh/mapstructure v1.4.1
@@ -29,7 +31,7 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect
 	golang.org/x/text v0.3.7 // indirect
-	google.golang.org/genproto v0.0.0-20210821163610-241b8fcbd6c8 // indirect
+	google.golang.org/genproto v0.0.0-20210821163610-241b8fcbd6c8
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0
 )

--- a/internal/cloudmonitoring/alert_labels.go
+++ b/internal/cloudmonitoring/alert_labels.go
@@ -1,0 +1,36 @@
+package cloudmonitoring
+
+import (
+	"fmt"
+	"github.com/broadinstitute/revere/internal/statuspage/statuspagetypes"
+)
+
+type AlertLabels struct {
+	ServiceName        string
+	ServiceEnvironment string
+	AlertType          statuspagetypes.Status
+}
+
+func (p *MonitoringPacket) ParseLabels() (*AlertLabels, error) {
+	serviceName, present := p.Incident.PolicyUserLabels["revere-service-name"]
+	if !present {
+		return nil, fmt.Errorf("alert labels lacked the service name in %+v", p)
+	}
+	serviceEnvironment, present := p.Incident.PolicyUserLabels["revere-service-environment"]
+	if !present {
+		return nil, fmt.Errorf("alert labels lacked the service environment in %+v", p)
+	}
+	alertTypeString, present := p.Incident.PolicyUserLabels["revere-alert-type"]
+	if !present {
+		return nil, fmt.Errorf("alert labels lacked the alert type in %+v", p)
+	}
+	alertType, err := statuspagetypes.StatusFromKebabCase(alertTypeString)
+	if err != nil {
+		return nil, fmt.Errorf("alert label's alert type incorrect format: %w", err)
+	}
+	return &AlertLabels{
+		ServiceName:        serviceName,
+		ServiceEnvironment: serviceEnvironment,
+		AlertType:          alertType,
+	}, nil
+}

--- a/internal/cloudmonitoring/alert_labels_test.go
+++ b/internal/cloudmonitoring/alert_labels_test.go
@@ -1,0 +1,93 @@
+package cloudmonitoring
+
+import (
+	"github.com/broadinstitute/revere/internal/statuspage/statuspagetypes"
+	"reflect"
+	"testing"
+)
+
+func TestMonitoringPacket_ParseLabels(t *testing.T) {
+	type fields struct {
+		Version  string
+		Incident *MonitoringIncident
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    *AlertLabels
+		wantErr bool
+	}{
+		{
+			name: "Parses properly",
+			fields: fields{Incident: &MonitoringIncident{PolicyUserLabels: map[string]string{
+				"revere-service-name":        "buffer",
+				"revere-service-environment": "prod",
+				"revere-alert-type":          "degraded-performance",
+				"another-random-label":       "random-value",
+			}}},
+			want: &AlertLabels{
+				ServiceName:        "buffer",
+				ServiceEnvironment: "prod",
+				AlertType:          statuspagetypes.DegradedPerformance,
+			},
+		},
+		{
+			name:    "Errors without labels",
+			fields:  fields{Incident: &MonitoringIncident{}},
+			wantErr: true,
+		},
+		{
+			name: "Errors without name",
+			fields: fields{Incident: &MonitoringIncident{PolicyUserLabels: map[string]string{
+				"revere-service-environment": "prod",
+				"revere-alert-type":          "degraded-performance",
+				"another-random-label":       "random-value",
+			}}},
+			wantErr: true,
+		},
+		{
+			name: "Errors without environment",
+			fields: fields{Incident: &MonitoringIncident{PolicyUserLabels: map[string]string{
+				"revere-service-name":  "buffer",
+				"revere-alert-type":    "degraded-performance",
+				"another-random-label": "random-value",
+			}}},
+			wantErr: true,
+		},
+		{
+			name: "Errors without alert type",
+			fields: fields{Incident: &MonitoringIncident{PolicyUserLabels: map[string]string{
+				"revere-service-name":        "buffer",
+				"revere-service-environment": "prod",
+				"another-random-label":       "random-value",
+			}}},
+			wantErr: true,
+		},
+		{
+			name: "Errors if alert type can't be parsed",
+			fields: fields{Incident: &MonitoringIncident{PolicyUserLabels: map[string]string{
+				"revere-service-name":        "buffer",
+				"revere-service-environment": "prod",
+				"revere-alert-type":          "nonsensical-value",
+				"another-random-label":       "random-value",
+			}}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &MonitoringPacket{
+				Version:  tt.fields.Version,
+				Incident: tt.fields.Incident,
+			}
+			got, err := p.ParseLabels()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseLabels() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseLabels() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cloudmonitoring/monitoring_packet.go
+++ b/internal/cloudmonitoring/monitoring_packet.go
@@ -1,0 +1,56 @@
+package cloudmonitoring
+
+import "google.golang.org/genproto/googleapis/monitoring/v3"
+
+// MonitoringPacket handles payloads from Webhook *or Pub/Sub*
+// https://cloud.google.com/monitoring/support/notification-options#webhooks
+// Pointers used for nested structs to avoid copying mutexes
+type MonitoringPacket struct {
+	Version  string              `json:"version"`
+	Incident *MonitoringIncident `json:"incident"`
+}
+
+// MonitoringIncident is the union of the v1.1 and v1.2 types, because v1.2 is
+// already a perfect superset of v1.1 save for the Errors field
+type MonitoringIncident struct {
+	// Incident
+	IncidentID string `json:"incident_id"`
+	URL        string `json:"url"`
+	State      string `json:"state"`
+	StartedAt  int64  `json:"started_at"`
+	EndedAt    int64  `json:"ended_at"`
+	Summary    string `json:"summary"`
+	ApigeeURL  string `json:"apigee_url"`
+
+	// Resource
+	Resource                *MonitoringResource `json:"resource"`
+	ResourceTypeDisplayName string              `json:"resource_type_display_name"`
+	ResourceID              string              `json:"resource_id"`
+	ResourceDisplayName     string              `json:"resource_display_name"`
+	ResourceName            string              `json:"resource_name"`
+
+	// Metric
+	Metric *MonitoringMetric `json:"metric"`
+
+	// Policy
+	PolicyName       string                                `json:"policy_name"`
+	PolicyUserLabels map[string]string                     `json:"policy_user_labels"`
+	Documentation    *monitoring.AlertPolicy_Documentation `json:"documentation"`
+	Condition        *monitoring.AlertPolicy_Condition     `json:"condition"`
+	ConditionName    string                                `json:"condition_name"`
+
+	// Errors (on Google's end in formulating the incident)
+	// Technically google.rpc.Status objects but pulling in all of gRPC
+	// to fully type errors seems pointless, we'd just dump them anyway
+	Errors []map[string]interface{} `json:"errors"`
+}
+
+type MonitoringResource struct {
+	Type   string            `json:"type"`
+	Labels map[string]string `json:"labels"`
+}
+
+type MonitoringMetric struct {
+	Type        string `json:"type"`
+	DisplayName string `json:"display_name"`
+}

--- a/internal/pubsub/receive_messages.go
+++ b/internal/pubsub/receive_messages.go
@@ -3,14 +3,27 @@ package pubsub
 import (
 	"cloud.google.com/go/pubsub"
 	"context"
+	"encoding/json"
 	"fmt"
+	"github.com/broadinstitute/revere/internal/cloudmonitoring"
 	"github.com/broadinstitute/revere/internal/configuration"
+	"github.com/broadinstitute/revere/internal/shared"
 )
 
 // receiveOnce should handle and acknowledge a single message; will run
 // asynchronously
 func receiveOnce(config *configuration.Config, msg *pubsub.Message) {
-	fmt.Printf("Message %q from %s", string(msg.Data), config.Pubsub.SubscriptionID)
+	var packet *cloudmonitoring.MonitoringPacket
+	if err := json.Unmarshal(msg.Data, &packet); err != nil {
+		shared.LogLn(config, "failed to parse packet", fmt.Sprintf("%+v", err))
+		return
+	}
+	labels, err := packet.ParseLabels()
+	if err != nil {
+		shared.LogLn(config, "failed to parse labels", fmt.Sprintf("%+v", err))
+		return
+	}
+	fmt.Printf("Alert %+v from %s", labels, config.Pubsub.SubscriptionID)
 	msg.Ack()
 }
 

--- a/internal/statuspage/statuspagetypes/status.go
+++ b/internal/statuspage/statuspagetypes/status.go
@@ -2,8 +2,10 @@ package statuspagetypes
 
 import "fmt"
 
+// Status represents the various component states understood by Statuspage.io
 type Status int
 
+// https://golang.org/ref/spec#Iota, https://golang.org/ref/spec#Constant_declarations
 const (
 	Operational Status = iota
 	DegradedPerformance

--- a/internal/statuspage/statuspagetypes/status.go
+++ b/internal/statuspage/statuspagetypes/status.go
@@ -1,0 +1,45 @@
+package statuspagetypes
+
+import "fmt"
+
+type Status int
+
+const (
+	Operational Status = iota
+	DegradedPerformance
+	PartialOutage
+	MajorOutage
+	UnderMaintenance
+)
+
+func (s Status) ToString() string {
+	switch s {
+	case Operational:
+		return "Operational"
+	case DegradedPerformance:
+		return "Degraded Performance"
+	case PartialOutage:
+		return "Partial Outage"
+	case MajorOutage:
+		return "Major Outage"
+	case UnderMaintenance:
+		return "Under Maintenance"
+	}
+	return fmt.Sprintf("Invalid Status %d", s)
+}
+
+func StatusFromKebabCase(kebabCaseString string) (Status, error) {
+	switch kebabCaseString {
+	case "operational":
+		return Operational, nil
+	case "degraded-performance":
+		return DegradedPerformance, nil
+	case "partial-outage":
+		return PartialOutage, nil
+	case "major-outage":
+		return MajorOutage, nil
+	case "under-maintenance":
+		return UnderMaintenance, nil
+	}
+	return -1, fmt.Errorf("%s cannot be parsed to a Status", kebabCaseString)
+}

--- a/internal/statuspage/statuspagetypes/status_test.go
+++ b/internal/statuspage/statuspagetypes/status_test.go
@@ -1,0 +1,105 @@
+package statuspagetypes
+
+import "testing"
+
+func TestStatus_ToString(t *testing.T) {
+	tests := []struct {
+		name string
+		s    Status
+		want string
+	}{
+		{
+			name: "Operational output",
+			s:    Operational,
+			want: "Operational",
+		},
+		{
+			name: "DegradedPerformance output",
+			s:    DegradedPerformance,
+			want: "Degraded Performance",
+		},
+		{
+			name: "PartialOutage output",
+			s:    PartialOutage,
+			want: "Partial Outage",
+		},
+		{
+			name: "MajorOutage output",
+			s:    MajorOutage,
+			want: "Major Outage",
+		},
+		{
+			name: "UnderMaintenance output",
+			s:    UnderMaintenance,
+			want: "Under Maintenance",
+		},
+		{
+			name: "Invalid status output",
+			s:    -1,
+			want: "Invalid Status -1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.s.ToString(); got != tt.want {
+				t.Errorf("ToString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatusFromKebabCase(t *testing.T) {
+	type args struct {
+		kebabCaseString string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Status
+		wantErr bool
+	}{
+		{
+			name: "operational parse",
+			args: args{kebabCaseString: "operational"},
+			want: Operational,
+		},
+		{
+			name: "degraded-performance parse",
+			args: args{kebabCaseString: "degraded-performance"},
+			want: DegradedPerformance,
+		},
+		{
+			name: "partial-outage parse",
+			args: args{kebabCaseString: "partial-outage"},
+			want: PartialOutage,
+		},
+		{
+			name: "major-outage parse",
+			args: args{kebabCaseString: "major-outage"},
+			want: MajorOutage,
+		},
+		{
+			name: "under-maintenance parse",
+			args: args{kebabCaseString: "under-maintenance"},
+			want: UnderMaintenance,
+		},
+		{
+			name:    "invalid parse",
+			args:    args{kebabCaseString: "invalid"},
+			want:    -1,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := StatusFromKebabCase(tt.args.kebabCaseString)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("StatusFromKebabCase() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("StatusFromKebabCase() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
PR 1 of 2, second one coming tomorrow. I'm still in the process of testing this but want to get it up for review because we're all sorta ending early today.

Goal here is to take incoming messages and read them, such that it prints out the labels associated with the alert policy. Part 2 will be doing some config file work so that instead of printing out the labels, it will print out what Statuspage / user-facing _components_ it will actually try to update.