### PR TITLE
[DDO-1647] Give Revere internal state, use it to coordinate updates to statuspage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,3 +75,12 @@ jobs:
 
       - name: Push image
         run: "docker push ${{ steps.image-name.outputs.name }}"
+
+      - name: Comment pushed image
+        uses: actions/github-script@0.3.0
+        if: github.event_name == 'pull_request'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
+            github.issues.createComment({ issue_number, owner, repo, body: 'Pushed image: ${{ steps.image-name.outputs.name }}' });

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Revere cares about **services** and **components**. A **service** is an internal
 
 Revere operates like this:
 1. Accept status information about **services** from event sources:
-   1. *[WIP: in-development]* Cloud Monitoring Alerts via Cloud Pub/Sub
+   1. Cloud Monitoring Alerts via Cloud Pub/Sub
 2. Translate those events to impacts on **components**
 3. Communicate those impacts to end-users:
-   1. *[WIP: in-development]* Statuspage.io
+   1.  Statuspage.io
     
 ## Usage
 
@@ -43,8 +43,25 @@ The configuration file's format is defined by [`internal/config.go`](https://git
 .
 ├── cmd/
 │   └── # CLI commands
+├── docs/
+│   └── # Long-form documentation
 ├── internal/
-│   └── # Service operation [stub, more to be added here]
+│   ├── api/
+│   │   └── # Barebones API routes
+│   ├── cloudmonitoring/
+│   │   └── # Data types from Google Cloud Monitoring
+│   ├── configuration/
+│   │   └── # Data types for Revere's config file
+│   ├── pubsub/
+│   │   └── # Handling for Google Pub/Sub
+│   ├── shared/
+│   │   └── # Shared utility functions
+│   ├── state/
+│   │   └── # Data types for Revere's internal state
+│   ├── statuspage/
+│   │   └── # Data types and handling for Atlassian Statuspage
+│   └── version/
+│       └── # Run-time reference to Revere's own version
 └── main.go # CLI entrypoint
 ```
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -5,10 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"github.com/broadinstitute/revere/internal/api"
+	"github.com/broadinstitute/revere/internal/cloudmonitoring"
 	"github.com/broadinstitute/revere/internal/configuration"
 	"github.com/broadinstitute/revere/internal/pubsub"
 	"github.com/broadinstitute/revere/internal/pubsub/pubsubapi"
 	"github.com/broadinstitute/revere/internal/shared"
+	"github.com/broadinstitute/revere/internal/state"
+	"github.com/broadinstitute/revere/internal/statuspage/statuspageapi"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
@@ -34,15 +37,31 @@ func Serve(*cobra.Command, []string) {
 	config, err := configuration.AssembleConfig(viper.GetViper())
 	cobra.CheckErr(err)
 
+	shared.LogLn(config, "preparing statuspage..")
+	statuspageClient := statuspageapi.Client(config)
+	statuspageComponents, err := statuspageapi.GetComponents(statuspageClient, config.Statuspage.PageID)
+	cobra.CheckErr(err)
+	componentNamesToIDs := make(map[string]string)
+	for _, component := range *statuspageComponents {
+		componentNamesToIDs[component.Name] = component.ID
+	}
+
+	shared.LogLn(config, "preparing pubsub...")
 	pubsubClient, err := pubsubapi.Client(config)
 	cobra.CheckErr(err)
 	pubsubCtx, cancelPubsub := context.WithCancel(context.Background())
 
+	shared.LogLn(config, "preparing api...")
 	apiServer := &http.Server{
 		Addr:    fmt.Sprintf(":%d", config.Api.Port),
 		Handler: api.NewRouter(config),
 	}
 
+	shared.LogLn(config, "deriving state...")
+	appState := &state.State{}
+	appState.Seed(componentNamesToIDs)
+
+	// Routines to run in parallel
 	routines := []struct {
 		runForever   func()
 		uponShutdown func() error
@@ -50,7 +69,23 @@ func Serve(*cobra.Command, []string) {
 		{
 			runForever: func() {
 				shared.LogLn(config, "listening to pubsub...")
-				err := pubsub.ReceiveMessages(config, pubsubClient, pubsubCtx)
+				err := pubsub.ReceiveMessages(config, pubsubClient, pubsubCtx,
+					// A callback is used here rather than tightly coupling pubsub with statuspage and state
+					func(componentName string, labels *cloudmonitoring.AlertLabels, incident *cloudmonitoring.MonitoringIncident) error {
+						return appState.UseComponent(componentName, func(c *state.ComponentState) error {
+							var shouldEdit bool
+							if incident.HasEnded() {
+								shouldEdit = c.ResolveIncident(incident.IncidentID)
+							} else {
+								shouldEdit = c.LogIncident(incident.IncidentID, labels.AlertType)
+							}
+							if shouldEdit {
+								_, err := statuspageapi.PatchComponentStatus(statuspageClient, config.Statuspage.PageID, c.GetID(), c.GetDesiredStatus())
+								return err
+							}
+							return nil
+						})
+					})
 				cobra.CheckErr(err)
 			},
 			uponShutdown: func() error {

--- a/internal/cloudmonitoring/monitoring_packet.go
+++ b/internal/cloudmonitoring/monitoring_packet.go
@@ -54,3 +54,15 @@ type MonitoringMetric struct {
 	Type        string `json:"type"`
 	DisplayName string `json:"display_name"`
 }
+
+func (i *MonitoringIncident) HasEnded() bool {
+	switch i.State {
+	case "open":
+		return false
+	case "closed":
+		return true
+	}
+	// The incident state is theoretically an enum, but failing that we return based
+	// on the incident having a sensible ending time
+	return i.EndedAt > i.StartedAt
+}

--- a/internal/cloudmonitoring/monitoring_packet.go
+++ b/internal/cloudmonitoring/monitoring_packet.go
@@ -61,8 +61,11 @@ func (i *MonitoringIncident) HasEnded() bool {
 		return false
 	case "closed":
 		return true
+	default:
+		// The incident state is theoretically an enum, but failing that we return based
+		// on the incident having a sensible ending time.
+		// Google silently removed docs on an older version of MonitoringIncident that
+		// lacked many of the fields of the modern one.
+		return i.EndedAt > i.StartedAt
 	}
-	// The incident state is theoretically an enum, but failing that we return based
-	// on the incident having a sensible ending time
-	return i.EndedAt > i.StartedAt
 }

--- a/internal/cloudmonitoring/monitoring_packet_test.go
+++ b/internal/cloudmonitoring/monitoring_packet_test.go
@@ -1,0 +1,84 @@
+package cloudmonitoring
+
+import (
+	"google.golang.org/genproto/googleapis/monitoring/v3"
+	"testing"
+)
+
+func TestMonitoringIncident_HasEnded(t *testing.T) {
+	type fields struct {
+		IncidentID              string
+		URL                     string
+		State                   string
+		StartedAt               int64
+		EndedAt                 int64
+		Summary                 string
+		ApigeeURL               string
+		Resource                *MonitoringResource
+		ResourceTypeDisplayName string
+		ResourceID              string
+		ResourceDisplayName     string
+		ResourceName            string
+		Metric                  *MonitoringMetric
+		PolicyName              string
+		PolicyUserLabels        map[string]string
+		Documentation           *monitoring.AlertPolicy_Documentation
+		Condition               *monitoring.AlertPolicy_Condition
+		ConditionName           string
+		Errors                  []map[string]interface{}
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name:   "Open",
+			fields: fields{State: "open"},
+			want:   false,
+		},
+		{
+			name:   "Closed",
+			fields: fields{State: "closed"},
+			want:   true,
+		},
+		{
+			name:   "Fallback open",
+			fields: fields{State: "foo", StartedAt: 12345},
+			want:   false,
+		},
+		{
+			name:   "Fallback closed",
+			fields: fields{State: "foo", StartedAt: 12345, EndedAt: 12349},
+			want:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &MonitoringIncident{
+				IncidentID:              tt.fields.IncidentID,
+				URL:                     tt.fields.URL,
+				State:                   tt.fields.State,
+				StartedAt:               tt.fields.StartedAt,
+				EndedAt:                 tt.fields.EndedAt,
+				Summary:                 tt.fields.Summary,
+				ApigeeURL:               tt.fields.ApigeeURL,
+				Resource:                tt.fields.Resource,
+				ResourceTypeDisplayName: tt.fields.ResourceTypeDisplayName,
+				ResourceID:              tt.fields.ResourceID,
+				ResourceDisplayName:     tt.fields.ResourceDisplayName,
+				ResourceName:            tt.fields.ResourceName,
+				Metric:                  tt.fields.Metric,
+				PolicyName:              tt.fields.PolicyName,
+				PolicyUserLabels:        tt.fields.PolicyUserLabels,
+				Documentation:           tt.fields.Documentation,
+				Condition:               tt.fields.Condition,
+				ConditionName:           tt.fields.ConditionName,
+				Errors:                  tt.fields.Errors,
+			}
+			if got := i.HasEnded(); got != tt.want {
+				t.Errorf("HasEnded() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/pubsub/pubsubtypes/handler.go
+++ b/internal/pubsub/pubsubtypes/handler.go
@@ -1,0 +1,7 @@
+package pubsubtypes
+
+import "github.com/broadinstitute/revere/internal/cloudmonitoring"
+
+// PerComponentHandler is an alias for a function handling the update of a single status.
+// It is abstracted so the type may be referenced in across the program without importing other code.
+type PerComponentHandler func(componentName string, labels *cloudmonitoring.AlertLabels, incident *cloudmonitoring.MonitoringIncident) error

--- a/internal/pubsub/receive_messages.go
+++ b/internal/pubsub/receive_messages.go
@@ -8,36 +8,62 @@ import (
 	"github.com/broadinstitute/revere/internal/cloudmonitoring"
 	"github.com/broadinstitute/revere/internal/configuration"
 	"github.com/broadinstitute/revere/internal/shared"
+	"os"
 )
 
-// receiveOnce should handle and acknowledge a single message; will run
-// asynchronously
-func receiveOnce(config *configuration.Config, msg *pubsub.Message) {
+type PerComponentHandler func(componentName string, labels *cloudmonitoring.AlertLabels, incident *cloudmonitoring.MonitoringIncident) error
+
+// receiveOnce should handle a single message; will run asynchronously
+func receiveOnce(config *configuration.Config, msg *pubsub.Message, callback PerComponentHandler) error {
+	// parse Google's data structure
 	var packet *cloudmonitoring.MonitoringPacket
 	if err := json.Unmarshal(msg.Data, &packet); err != nil {
 		shared.LogLn(config, "failed to parse packet", fmt.Sprintf("%+v", err))
-		return
+		return err
 	}
+
+	// parse Revere's labels
 	labels, err := packet.ParseLabels()
 	if err != nil {
 		shared.LogLn(config, "failed to parse labels", fmt.Sprintf("%+v", err))
-		return
+		return err
 	}
-	fmt.Printf("Alert %+v from %s\n", labels, config.Pubsub.SubscriptionID)
+	shared.LogLn(config,
+		fmt.Sprintf("pubsub alert %s from %s", packet.Incident.PolicyName, config.Pubsub.SubscriptionID),
+		fmt.Sprintf("	%+v", labels),
+		fmt.Sprintf("	AlertType %d corresponds to %s", labels.AlertType, labels.AlertType.ToString()),
+		fmt.Sprintf("	incident is reporting as closed: %v", packet.Incident.HasEnded()))
+
+	// execute callback for each affected component
 	for _, serviceMapping := range config.ServiceToComponentMapping {
 		if serviceMapping.ServiceName == labels.ServiceName &&
 			serviceMapping.ServiceEnvironment == labels.ServiceEnvironment {
-			fmt.Printf("Affects components %+v", serviceMapping.AffectsComponentsNamed)
+			for _, componentName := range serviceMapping.AffectsComponentsNamed {
+				shared.LogLn(config,
+					fmt.Sprintf("pubsub alert %s affects %s, executing callback...", packet.Incident.IncidentID, componentName))
+				if err := callback(componentName, labels, packet.Incident); err != nil {
+					shared.LogLn(config,
+						"failed to execute callback", fmt.Sprintf("%+v", err))
+					return err
+				}
+			}
 		}
 	}
-	msg.Ack()
+	return nil
 }
 
-// ReceiveMessages should never terminate, it continually pulls messages from
-// the subscription
-func ReceiveMessages(config *configuration.Config, client *pubsub.Client, ctx context.Context) error {
+// ReceiveMessages should never terminate, it continually pulls messages from the subscription
+func ReceiveMessages(config *configuration.Config, client *pubsub.Client, ctx context.Context, callback PerComponentHandler) error {
 	subscription := client.Subscription(config.Pubsub.SubscriptionID)
 	return subscription.Receive(ctx, func(cctx context.Context, msg *pubsub.Message) {
-		receiveOnce(config, msg)
+		if err := receiveOnce(config, msg, callback); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			// There may be multiple infinite goroutines (see serve.go), to exit we have to do so forcibly.
+			// We specifically don't call msg.Nack before doing so because we want to let the lease expire,
+			// instead of pubsub retrying it immediately and *then* having it time out because we've exited.
+			os.Exit(1)
+		} else {
+			msg.Ack()
+		}
 	})
 }

--- a/internal/pubsub/receive_messages.go
+++ b/internal/pubsub/receive_messages.go
@@ -7,14 +7,13 @@ import (
 	"fmt"
 	"github.com/broadinstitute/revere/internal/cloudmonitoring"
 	"github.com/broadinstitute/revere/internal/configuration"
+	"github.com/broadinstitute/revere/internal/pubsub/pubsubtypes"
 	"github.com/broadinstitute/revere/internal/shared"
 	"os"
 )
 
-type PerComponentHandler func(componentName string, labels *cloudmonitoring.AlertLabels, incident *cloudmonitoring.MonitoringIncident) error
-
 // receiveOnce should handle a single message; will run asynchronously
-func receiveOnce(config *configuration.Config, msg *pubsub.Message, callback PerComponentHandler) error {
+func receiveOnce(config *configuration.Config, msg *pubsub.Message, callback pubsubtypes.PerComponentHandler) error {
 	// parse Google's data structure
 	var packet *cloudmonitoring.MonitoringPacket
 	if err := json.Unmarshal(msg.Data, &packet); err != nil {
@@ -53,7 +52,7 @@ func receiveOnce(config *configuration.Config, msg *pubsub.Message, callback Per
 }
 
 // ReceiveMessages should never terminate, it continually pulls messages from the subscription
-func ReceiveMessages(config *configuration.Config, client *pubsub.Client, ctx context.Context, callback PerComponentHandler) error {
+func ReceiveMessages(config *configuration.Config, client *pubsub.Client, ctx context.Context, callback pubsubtypes.PerComponentHandler) error {
 	subscription := client.Subscription(config.Pubsub.SubscriptionID)
 	return subscription.Receive(ctx, func(cctx context.Context, msg *pubsub.Message) {
 		if err := receiveOnce(config, msg, callback); err != nil {

--- a/internal/state/component_state.go
+++ b/internal/state/component_state.go
@@ -1,0 +1,52 @@
+package state
+
+import (
+	"github.com/broadinstitute/revere/internal/statuspage/statuspagetypes"
+	"sync"
+)
+
+type ComponentState struct {
+	openIncidents map[string]statuspagetypes.Status
+	desiredStatus statuspagetypes.Status
+	id            string
+	lock          *sync.Mutex
+}
+
+// recalculateDesiresStatus updates the cached desiresStatus and returns a bool representing if the value changed.
+func (c *ComponentState) recalculateDesiredStatus() bool {
+	worstStatusSoFar := statuspagetypes.Operational
+	for _, status := range c.openIncidents {
+		worstStatusSoFar = worstStatusSoFar.WorstWith(status)
+	}
+	if worstStatusSoFar != c.desiredStatus {
+		c.desiredStatus = worstStatusSoFar
+		return true
+	}
+	return false
+}
+
+// GetID returns the Statuspage ID correlating to this component.
+func (c *ComponentState) GetID() string {
+	return c.id
+}
+
+// GetDesiredStatus returns the status that the component should have. This can be cached
+// so long as it is recalculated when a component's incidents change.
+func (c *ComponentState) GetDesiredStatus() statuspagetypes.Status {
+	return c.desiredStatus
+}
+
+// LogIncident notes a new/updated incident affecting the status of the component.
+// The returned bool represents if the component's entire status changed based on the new incident.
+func (c *ComponentState) LogIncident(incidentID string, componentStatus statuspagetypes.Status) bool {
+	c.openIncidents[incidentID] = componentStatus
+	return c.recalculateDesiredStatus()
+}
+
+// ResolveIncident notes than an incident is no longer affecting the status of the component.
+// Has no effect if the incident has already been resolved or never existed/
+// The return bool represents if the component's entire status changed based on the resolved incident.
+func (c *ComponentState) ResolveIncident(incidentID string) bool {
+	delete(c.openIncidents, incidentID)
+	return c.recalculateDesiredStatus()
+}

--- a/internal/state/component_state.go
+++ b/internal/state/component_state.go
@@ -5,6 +5,9 @@ import (
 	"sync"
 )
 
+// ComponentState records information about components that's derived during continuous operation.
+// Its fields shouldn't be operated on in parallel; it contains a sync.Mutex to help state.State
+// manage attempts at concurrent access.
 type ComponentState struct {
 	openIncidents map[string]statuspagetypes.Status
 	desiredStatus statuspagetypes.Status

--- a/internal/state/component_state_test.go
+++ b/internal/state/component_state_test.go
@@ -1,0 +1,333 @@
+package state
+
+import (
+	"github.com/broadinstitute/revere/internal/statuspage/statuspagetypes"
+	"github.com/google/go-cmp/cmp"
+	"sync"
+	"testing"
+)
+
+func TestComponentState_GetDesiredStatus(t *testing.T) {
+	type fields struct {
+		openIncidents map[string]statuspagetypes.Status
+		desiredStatus statuspagetypes.Status
+		id            string
+		lock          *sync.Mutex
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   statuspagetypes.Status
+	}{
+		{
+			name: "Basic",
+			fields: fields{
+				desiredStatus: statuspagetypes.Operational,
+			},
+			want: statuspagetypes.Operational,
+		},
+		{
+			name: "Does not recalculate on its own!",
+			fields: fields{
+				openIncidents: map[string]statuspagetypes.Status{
+					"foo": statuspagetypes.PartialOutage,
+				},
+				desiredStatus: statuspagetypes.Operational,
+			},
+			want: statuspagetypes.Operational,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ComponentState{
+				openIncidents: tt.fields.openIncidents,
+				desiredStatus: tt.fields.desiredStatus,
+				id:            tt.fields.id,
+				lock:          tt.fields.lock,
+			}
+			if got := c.GetDesiredStatus(); got != tt.want {
+				t.Errorf("GetDesiredStatus() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComponentState_GetID(t *testing.T) {
+	type fields struct {
+		openIncidents map[string]statuspagetypes.Status
+		desiredStatus statuspagetypes.Status
+		id            string
+		lock          *sync.Mutex
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "Basic",
+			fields: fields{
+				id: "foo",
+			},
+			want: "foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ComponentState{
+				openIncidents: tt.fields.openIncidents,
+				desiredStatus: tt.fields.desiredStatus,
+				id:            tt.fields.id,
+				lock:          tt.fields.lock,
+			}
+			if got := c.GetID(); got != tt.want {
+				t.Errorf("GetID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComponentState_LogIncident(t *testing.T) {
+	type fields struct {
+		openIncidents map[string]statuspagetypes.Status
+		desiredStatus statuspagetypes.Status
+		id            string
+		lock          *sync.Mutex
+	}
+	type args struct {
+		incidentID      string
+		componentStatus statuspagetypes.Status
+	}
+	tests := []struct {
+		name              string
+		fields            fields
+		args              args
+		want              bool
+		wantIncidents     map[string]statuspagetypes.Status
+		wantDesiredStatus statuspagetypes.Status
+	}{
+		{
+			name: "New incident",
+			fields: fields{
+				openIncidents: map[string]statuspagetypes.Status{},
+				desiredStatus: statuspagetypes.Operational,
+			},
+			args: args{
+				incidentID:      "abc",
+				componentStatus: statuspagetypes.MajorOutage,
+			},
+			want: true,
+			wantIncidents: map[string]statuspagetypes.Status{
+				"abc": statuspagetypes.MajorOutage,
+			},
+			wantDesiredStatus: statuspagetypes.MajorOutage,
+		},
+		{
+			name: "Upgrade existing incident",
+			fields: fields{
+				openIncidents: map[string]statuspagetypes.Status{
+					"abc": statuspagetypes.PartialOutage,
+				},
+				desiredStatus: statuspagetypes.PartialOutage,
+			},
+			args: args{
+				incidentID:      "abc",
+				componentStatus: statuspagetypes.MajorOutage,
+			},
+			want: true,
+			wantIncidents: map[string]statuspagetypes.Status{
+				"abc": statuspagetypes.MajorOutage,
+			},
+			wantDesiredStatus: statuspagetypes.MajorOutage,
+		},
+		{
+			name: "Downgrade existing incident",
+			fields: fields{
+				openIncidents: map[string]statuspagetypes.Status{
+					"abc": statuspagetypes.MajorOutage,
+				},
+				desiredStatus: statuspagetypes.MajorOutage,
+			},
+			args: args{
+				incidentID:      "abc",
+				componentStatus: statuspagetypes.PartialOutage,
+			},
+			want: true,
+			wantIncidents: map[string]statuspagetypes.Status{
+				"abc": statuspagetypes.PartialOutage,
+			},
+			wantDesiredStatus: statuspagetypes.PartialOutage,
+		},
+		{
+			name: "No-op existing incident",
+			fields: fields{
+				openIncidents: map[string]statuspagetypes.Status{
+					"abc": statuspagetypes.MajorOutage,
+				},
+				desiredStatus: statuspagetypes.MajorOutage,
+			},
+			args: args{
+				incidentID:      "abc",
+				componentStatus: statuspagetypes.MajorOutage,
+			},
+			want: false,
+			wantIncidents: map[string]statuspagetypes.Status{
+				"abc": statuspagetypes.MajorOutage,
+			},
+			wantDesiredStatus: statuspagetypes.MajorOutage,
+		},
+		{
+			name: "Add additional incident",
+			fields: fields{
+				openIncidents: map[string]statuspagetypes.Status{
+					"abc": statuspagetypes.PartialOutage,
+				},
+				desiredStatus: statuspagetypes.PartialOutage,
+			},
+			args: args{
+				incidentID:      "def",
+				componentStatus: statuspagetypes.MajorOutage,
+			},
+			want: true,
+			wantIncidents: map[string]statuspagetypes.Status{
+				"abc": statuspagetypes.PartialOutage,
+				"def": statuspagetypes.MajorOutage,
+			},
+			wantDesiredStatus: statuspagetypes.MajorOutage,
+		},
+		{
+			name: "Add additional incident without effect",
+			fields: fields{
+				openIncidents: map[string]statuspagetypes.Status{
+					"abc": statuspagetypes.PartialOutage,
+				},
+				desiredStatus: statuspagetypes.PartialOutage,
+			},
+			args: args{
+				incidentID:      "def",
+				componentStatus: statuspagetypes.DegradedPerformance,
+			},
+			want: false,
+			wantIncidents: map[string]statuspagetypes.Status{
+				"abc": statuspagetypes.PartialOutage,
+				"def": statuspagetypes.DegradedPerformance,
+			},
+			wantDesiredStatus: statuspagetypes.PartialOutage,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ComponentState{
+				openIncidents: tt.fields.openIncidents,
+				desiredStatus: tt.fields.desiredStatus,
+				id:            tt.fields.id,
+				lock:          tt.fields.lock,
+			}
+			if got := c.LogIncident(tt.args.incidentID, tt.args.componentStatus); got != tt.want {
+				t.Errorf("LogIncident() = %v, want %v", got, tt.want)
+			}
+			if diff := cmp.Diff(tt.wantIncidents, c.openIncidents); diff != "" {
+				t.Errorf("LogIncident() bad effect: %s", diff)
+			}
+			if c.desiredStatus != tt.wantDesiredStatus {
+				t.Errorf("LogIncident() bad effect: got desiredStatus %v, want %v", c.desiredStatus, tt.wantDesiredStatus)
+			}
+		})
+	}
+}
+
+func TestComponentState_ResolveIncident(t *testing.T) {
+	type fields struct {
+		openIncidents map[string]statuspagetypes.Status
+		desiredStatus statuspagetypes.Status
+		id            string
+		lock          *sync.Mutex
+	}
+	type args struct {
+		incidentID string
+	}
+	tests := []struct {
+		name              string
+		fields            fields
+		args              args
+		want              bool
+		wantIncidents     map[string]statuspagetypes.Status
+		wantDesiredStatus statuspagetypes.Status
+	}{
+		{
+			name: "Non-existent",
+			fields: fields{
+				openIncidents: map[string]statuspagetypes.Status{},
+				desiredStatus: statuspagetypes.Operational,
+			},
+			args:              args{incidentID: "foo"},
+			want:              false,
+			wantIncidents:     map[string]statuspagetypes.Status{},
+			wantDesiredStatus: statuspagetypes.Operational,
+		},
+		{
+			name: "Basic removal",
+			fields: fields{
+				openIncidents: map[string]statuspagetypes.Status{
+					"abc": statuspagetypes.DegradedPerformance,
+				},
+				desiredStatus: statuspagetypes.DegradedPerformance,
+			},
+			args:              args{incidentID: "abc"},
+			want:              true,
+			wantIncidents:     map[string]statuspagetypes.Status{},
+			wantDesiredStatus: statuspagetypes.Operational,
+		},
+		{
+			name: "Downgrade removal",
+			fields: fields{
+				openIncidents: map[string]statuspagetypes.Status{
+					"abc": statuspagetypes.DegradedPerformance,
+					"def": statuspagetypes.MajorOutage,
+				},
+				desiredStatus: statuspagetypes.MajorOutage,
+			},
+			args: args{incidentID: "def"},
+			want: true,
+			wantIncidents: map[string]statuspagetypes.Status{
+				"abc": statuspagetypes.DegradedPerformance,
+			},
+			wantDesiredStatus: statuspagetypes.DegradedPerformance,
+		},
+		{
+			name: "No effect removal",
+			fields: fields{
+				openIncidents: map[string]statuspagetypes.Status{
+					"abc": statuspagetypes.DegradedPerformance,
+					"def": statuspagetypes.MajorOutage,
+				},
+				desiredStatus: statuspagetypes.MajorOutage,
+			},
+			args: args{incidentID: "abc"},
+			want: false,
+			wantIncidents: map[string]statuspagetypes.Status{
+				"def": statuspagetypes.MajorOutage,
+			},
+			wantDesiredStatus: statuspagetypes.MajorOutage,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ComponentState{
+				openIncidents: tt.fields.openIncidents,
+				desiredStatus: tt.fields.desiredStatus,
+				id:            tt.fields.id,
+				lock:          tt.fields.lock,
+			}
+			if got := c.ResolveIncident(tt.args.incidentID); got != tt.want {
+				t.Errorf("ResolveIncident() = %v, want %v", got, tt.want)
+			}
+			if diff := cmp.Diff(tt.wantIncidents, c.openIncidents); diff != "" {
+				t.Errorf("ResolveIncident() bad effect: %s", diff)
+			}
+			if c.desiredStatus != tt.wantDesiredStatus {
+				t.Errorf("ResolveIncident() bad effect: got desiredStatus %v, want %v", c.desiredStatus, tt.wantDesiredStatus)
+			}
+		})
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -6,6 +6,13 @@ import (
 	"sync"
 )
 
+// State contains information necessary for continuous operation that's derived throughout
+// the course of operation. Information not meeting that constraint should exist elsewhere
+// (like configuration.Config).
+// Right now, the only information meeting this criteria is per-component state.
+//
+// This object is responsible for making sure that concurrent users don't step on each
+// other.
 type State struct {
 	componentNameToState *sync.Map
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,0 +1,43 @@
+package state
+
+import (
+	"fmt"
+	"github.com/broadinstitute/revere/internal/statuspage/statuspagetypes"
+	"sync"
+)
+
+type State struct {
+	componentNameToState *sync.Map
+}
+
+// Seed the State with the component ID information obtained from Statuspage.
+func (s *State) Seed(componentNamesToIDs map[string]string) {
+	if s.componentNameToState == nil {
+		s.componentNameToState = &sync.Map{}
+	}
+	for name, id := range componentNamesToIDs {
+		uncastedComponentState, _ := s.componentNameToState.LoadOrStore(name, &ComponentState{
+			lock:          &sync.Mutex{},
+			openIncidents: map[string]statuspagetypes.Status{},
+		})
+		componentState := uncastedComponentState.(*ComponentState)
+		componentState.lock.Lock()
+		componentState.id = id
+		componentState.lock.Unlock()
+	}
+}
+
+// UseComponent runs a hook function with the state of some component. This function should
+// ensure that hooks never run simultaneously against the same component so long as callers
+// never copy the reference to the ComponentState object.
+func (s *State) UseComponent(componentName string, hook func(c *ComponentState) error) error {
+	uncastedComponentState, found := s.componentNameToState.Load(componentName)
+	if !found {
+		return fmt.Errorf("did not find component named %s", componentName)
+	}
+	componentState := uncastedComponentState.(*ComponentState)
+	componentState.lock.Lock()
+	err := hook(componentState)
+	componentState.lock.Unlock()
+	return err
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -37,6 +37,8 @@ func (s *State) Seed(componentNamesToIDs map[string]string) {
 // UseComponent runs a hook function with the state of some component. This function should
 // ensure that hooks never run simultaneously against the same component so long as callers
 // never copy the reference to the ComponentState object.
+//
+// For more explanation, see the usage of this function in statuspage.StatusUpdater()
 func (s *State) UseComponent(componentName string, hook func(c *ComponentState) error) error {
 	uncastedComponentState, found := s.componentNameToState.Load(componentName)
 	if !found {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,82 @@
+package state
+
+import (
+	"testing"
+)
+
+func dummyState() *State {
+	s := &State{}
+	s.Seed(map[string]string{
+		"foo": "foo-id",
+		"bar": "bar-id",
+		"baz": "baz-id",
+	})
+	return s
+}
+
+func TestInMemoryComponentState_GetID(t *testing.T) {
+	tests := []struct {
+		name     string
+		starting *State
+		seed     map[string]string
+		wantName string
+		wantID   string
+		wantErr  bool
+	}{
+		{
+			name: "Basic",
+			seed: map[string]string{
+				"foo": "foo-id",
+				"bar": "bar-id",
+			},
+			wantName: "foo",
+			wantID:   "foo-id",
+		},
+		{
+			name:     "Updating",
+			starting: dummyState(),
+			seed: map[string]string{
+				"foo": "foo-id-2",
+			},
+			wantName: "foo",
+			wantID:   "foo-id-2",
+		},
+		{
+			name:     "Errors with blank",
+			seed:     map[string]string{},
+			wantName: "foo",
+			wantErr:  true,
+		},
+		{
+			name: "Errors with missing",
+			seed: map[string]string{
+				"bar": "bar-id",
+			},
+			wantName: "foo",
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var s *State
+			if tt.starting != nil {
+				s = tt.starting
+			} else {
+				s = &State{}
+			}
+			s.Seed(tt.seed)
+			var got string
+			err := s.UseComponent(tt.wantName, func(c *ComponentState) error {
+				got = c.GetID()
+				return nil
+			})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetID() error %v", err)
+				return
+			}
+			if got != tt.wantID {
+				t.Errorf("GetID() = %v, want %v", got, tt.wantID)
+			}
+		})
+	}
+}

--- a/internal/statuspage/stateful_update_status.go
+++ b/internal/statuspage/stateful_update_status.go
@@ -1,0 +1,46 @@
+package statuspage
+
+import (
+	"github.com/broadinstitute/revere/internal/cloudmonitoring"
+	"github.com/broadinstitute/revere/internal/configuration"
+	"github.com/broadinstitute/revere/internal/pubsub/pubsubtypes"
+	"github.com/broadinstitute/revere/internal/state"
+	"github.com/broadinstitute/revere/internal/statuspage/statuspageapi"
+	"github.com/go-resty/resty/v2"
+)
+
+// StatusUpdater returns a function to handle a possible update against a single component.
+// The returned function is correctly typed to be called by pubsub.ReceiveMessages as a callback.
+func StatusUpdater(config *configuration.Config, appState *state.State, client *resty.Client) pubsubtypes.PerComponentHandler {
+
+	// StatusUpdater returns a function with arguments only for what changes per-component. Even though the function
+	// takes advantage of config/appState/client, it has a narrow signature in line with what the pubsub package
+	// parses from an incoming message.
+	return func(componentName string, labels *cloudmonitoring.AlertLabels, incident *cloudmonitoring.MonitoringIncident) error {
+
+		// Within the StatusUpdater's returned function, we wrap all work inside the appState.UseComponent hook.
+		// 		This is a bit like a React useEffect hook! If that makes no sense, read on:
+		//
+		// 1. By wrapping the work here in a UseComponent hook, the appState gives us access to the ComponentState, so we
+		// can record the incident and get the component's ID and status.
+		// 2. The appState manages this access so that no two hooks will ever run simultaneously against the same
+		// component.
+		// 3. Because the entire body of this function is within the hook, this function does not need to worry about
+		// concurrency control.
+		// 4. **This eliminates a class of race conditions arising out of delay around status changes (both in-memory
+		// __and__ in communicating with Statuspage.io)**
+		return appState.UseComponent(componentName, func(c *state.ComponentState) error {
+			var componentStatusChanged bool
+			if incident.HasEnded() {
+				componentStatusChanged = c.ResolveIncident(incident.IncidentID)
+			} else {
+				componentStatusChanged = c.LogIncident(incident.IncidentID, labels.AlertType)
+			}
+			if componentStatusChanged {
+				_, err := statuspageapi.PatchComponentStatus(client, config.Statuspage.PageID, c.GetID(), c.GetDesiredStatus())
+				return err
+			}
+			return nil
+		})
+	}
+}

--- a/internal/statuspage/stateful_update_status_test.go
+++ b/internal/statuspage/stateful_update_status_test.go
@@ -1,0 +1,342 @@
+package statuspage
+
+import (
+	"github.com/broadinstitute/revere/internal/cloudmonitoring"
+	"github.com/broadinstitute/revere/internal/configuration"
+	"github.com/broadinstitute/revere/internal/state"
+	"github.com/broadinstitute/revere/internal/statuspage/statuspageapi"
+	"github.com/broadinstitute/revere/internal/statuspage/statuspagemocks"
+	"github.com/broadinstitute/revere/internal/statuspage/statuspagetypes"
+	"github.com/jarcoal/httpmock"
+	"testing"
+)
+
+func makeConfigHelper(components []configuration.Component, serviceToComponentMapping []configuration.ServiceToComponentMapping) *configuration.Config {
+	return &configuration.Config{
+		Verbose: false,
+		Client: struct {
+			Redirects int
+			Retries   int
+		}{Redirects: 3, Retries: 3},
+		Statuspage: struct {
+			ApiKey     string `validate:"required"`
+			PageID     string `validate:"required"`
+			ApiRoot    string
+			Components []configuration.Component      `validate:"unique=Name,dive"`
+			Groups     []configuration.ComponentGroup `validate:"unique=Name,dive"`
+		}{
+			ApiKey: "foo", PageID: "bar", ApiRoot: "https://localhost",
+			Components: components,
+		},
+		ServiceToComponentMapping: serviceToComponentMapping,
+	}
+}
+
+func TestStatusUpdater(t *testing.T) {
+	type args struct {
+		config       *configuration.Config
+		appStateSeed map[string]string
+		mockState    map[string]statuspagetypes.Component
+	}
+	type resultArgs struct {
+		componentName string
+		labels        *cloudmonitoring.AlertLabels
+		incident      *cloudmonitoring.MonitoringIncident
+	}
+	tests := []struct {
+		name string
+		// Args passed to the StatusUpdater function
+		args args
+		// Extra modifications made to the state (so we can pretend there are already incidents there)
+		stateModifications func(appState *state.State)
+		// Args passed to StatusUpdater's result when we call it for effect
+		resultArgs resultArgs
+		// Desired status of the component (in-memory and in-mock) after calling StatusUpdater's result
+		wantStatus statuspagetypes.Status
+		wantErr    bool
+	}{
+		{
+			name: "plain update",
+			args: args{
+				config: makeConfigHelper(
+					[]configuration.Component{
+						{Name: "a component"},
+					},
+					[]configuration.ServiceToComponentMapping{
+						{
+							ServiceName: "a service", ServiceEnvironment: "an environment",
+							AffectsComponentsNamed: []string{"a component"},
+						},
+					}),
+				appStateSeed: map[string]string{
+					"a component": "a-component-id",
+				},
+				mockState: map[string]statuspagetypes.Component{
+					"a-component-id": {Name: "a component", ID: "a-component-id", Status: "operational"},
+				},
+			},
+			resultArgs: resultArgs{
+				componentName: "a component",
+				labels:        &cloudmonitoring.AlertLabels{AlertType: statuspagetypes.MajorOutage},
+				incident: &cloudmonitoring.MonitoringIncident{
+					IncidentID: "an-incident-id",
+					State:      "open",
+				},
+			},
+			wantStatus: statuspagetypes.MajorOutage,
+		},
+		{
+			name: "plain resolve",
+			args: args{
+				config: makeConfigHelper(
+					[]configuration.Component{
+						{Name: "a component"},
+					},
+					[]configuration.ServiceToComponentMapping{
+						{
+							ServiceName: "a service", ServiceEnvironment: "an environment",
+							AffectsComponentsNamed: []string{"a component"},
+						},
+					}),
+				appStateSeed: map[string]string{
+					"a component": "a-component-id",
+				},
+				mockState: map[string]statuspagetypes.Component{
+					"a-component-id": {Name: "a component", ID: "a-component-id", Status: "major_outage"},
+				},
+			},
+			stateModifications: func(appState *state.State) {
+				_ = appState.UseComponent("a component", func(c *state.ComponentState) error {
+					c.LogIncident("an-incident-id", statuspagetypes.MajorOutage)
+					return nil
+				})
+			},
+			resultArgs: resultArgs{
+				componentName: "a component",
+				labels:        &cloudmonitoring.AlertLabels{AlertType: statuspagetypes.MajorOutage},
+				incident: &cloudmonitoring.MonitoringIncident{
+					IncidentID: "an-incident-id",
+					State:      "closed",
+				},
+			},
+			wantStatus: statuspagetypes.Operational,
+		},
+		{
+			name: "no-op update (duplicate incident log)",
+			args: args{
+				config: makeConfigHelper(
+					[]configuration.Component{
+						{Name: "a component"},
+					},
+					[]configuration.ServiceToComponentMapping{
+						{
+							ServiceName: "a service", ServiceEnvironment: "an environment",
+							AffectsComponentsNamed: []string{"a component"},
+						},
+					}),
+				appStateSeed: map[string]string{
+					"a component": "a-component-id",
+				},
+				mockState: map[string]statuspagetypes.Component{
+					"a-component-id": {Name: "a component", ID: "a-component-id", Status: "major_outage"},
+				},
+			},
+			stateModifications: func(appState *state.State) {
+				_ = appState.UseComponent("a component", func(c *state.ComponentState) error {
+					// Force the state to already contain this incident
+					c.LogIncident("an-incident-id", statuspagetypes.MajorOutage)
+					return nil
+				})
+			},
+			resultArgs: resultArgs{
+				componentName: "a component",
+				labels:        &cloudmonitoring.AlertLabels{AlertType: statuspagetypes.MajorOutage},
+				incident: &cloudmonitoring.MonitoringIncident{
+					IncidentID: "an-incident-id",
+					State:      "open",
+				},
+			},
+			wantStatus: statuspagetypes.MajorOutage,
+		},
+		{
+			name: "no-op update (duplicate incident resolve)",
+			args: args{
+				config: makeConfigHelper(
+					[]configuration.Component{
+						{Name: "a component"},
+					},
+					[]configuration.ServiceToComponentMapping{
+						{
+							ServiceName: "a service", ServiceEnvironment: "an environment",
+							AffectsComponentsNamed: []string{"a component"},
+						},
+					}),
+				appStateSeed: map[string]string{
+					"a component": "a-component-id",
+				},
+				mockState: map[string]statuspagetypes.Component{
+					"a-component-id": {Name: "a component", ID: "a-component-id", Status: "operational"},
+				},
+			},
+			resultArgs: resultArgs{
+				componentName: "a component",
+				labels:        &cloudmonitoring.AlertLabels{AlertType: statuspagetypes.MajorOutage},
+				incident: &cloudmonitoring.MonitoringIncident{
+					IncidentID: "an-incident-id",
+					State:      "closed",
+				},
+			},
+			wantStatus: statuspagetypes.Operational,
+		},
+		{
+			name: "upgrade with new incident",
+			args: args{
+				config: makeConfigHelper(
+					[]configuration.Component{
+						{Name: "a component"},
+					},
+					[]configuration.ServiceToComponentMapping{
+						{
+							ServiceName: "a service", ServiceEnvironment: "an environment",
+							AffectsComponentsNamed: []string{"a component"},
+						},
+					}),
+				appStateSeed: map[string]string{
+					"a component": "a-component-id",
+				},
+				mockState: map[string]statuspagetypes.Component{
+					"a-component-id": {Name: "a component", ID: "a-component-id", Status: "partial_outage"},
+				},
+			},
+			stateModifications: func(appState *state.State) {
+				_ = appState.UseComponent("a component", func(c *state.ComponentState) error {
+					// Force the state to already contain a lesser incident
+					c.LogIncident("another-incident-id", statuspagetypes.PartialOutage)
+					return nil
+				})
+			},
+			resultArgs: resultArgs{
+				componentName: "a component",
+				labels:        &cloudmonitoring.AlertLabels{AlertType: statuspagetypes.MajorOutage},
+				incident: &cloudmonitoring.MonitoringIncident{
+					IncidentID: "an-incident-id",
+					State:      "open",
+				},
+			},
+			wantStatus: statuspagetypes.MajorOutage,
+		},
+		{
+			name: "no-op with new lesser incident",
+			args: args{
+				config: makeConfigHelper(
+					[]configuration.Component{
+						{Name: "a component"},
+					},
+					[]configuration.ServiceToComponentMapping{
+						{
+							ServiceName: "a service", ServiceEnvironment: "an environment",
+							AffectsComponentsNamed: []string{"a component"},
+						},
+					}),
+				appStateSeed: map[string]string{
+					"a component": "a-component-id",
+				},
+				mockState: map[string]statuspagetypes.Component{
+					"a-component-id": {Name: "a component", ID: "a-component-id", Status: "partial_outage"},
+				},
+			},
+			stateModifications: func(appState *state.State) {
+				_ = appState.UseComponent("a component", func(c *state.ComponentState) error {
+					// Force the state to already contain an incident
+					c.LogIncident("another-incident-id", statuspagetypes.PartialOutage)
+					return nil
+				})
+			},
+			resultArgs: resultArgs{
+				componentName: "a component",
+				labels:        &cloudmonitoring.AlertLabels{AlertType: statuspagetypes.DegradedPerformance},
+				incident: &cloudmonitoring.MonitoringIncident{
+					IncidentID: "an-incident-id",
+					State:      "open",
+				},
+			},
+			wantStatus: statuspagetypes.PartialOutage,
+		},
+		{
+			name: "downgrade to lesser incident",
+			args: args{
+				config: makeConfigHelper(
+					[]configuration.Component{
+						{Name: "a component"},
+					},
+					[]configuration.ServiceToComponentMapping{
+						{
+							ServiceName: "a service", ServiceEnvironment: "an environment",
+							AffectsComponentsNamed: []string{"a component"},
+						},
+					}),
+				appStateSeed: map[string]string{
+					"a component": "a-component-id",
+				},
+				mockState: map[string]statuspagetypes.Component{
+					"a-component-id": {Name: "a component", ID: "a-component-id", Status: "partial_outage"},
+				},
+			},
+			stateModifications: func(appState *state.State) {
+				_ = appState.UseComponent("a component", func(c *state.ComponentState) error {
+					// Force the state to already contain an incident
+					c.LogIncident("another-incident-id", statuspagetypes.PartialOutage)
+					c.LogIncident("an-incident-id", statuspagetypes.DegradedPerformance)
+					return nil
+				})
+			},
+			resultArgs: resultArgs{
+				componentName: "a component",
+				labels:        &cloudmonitoring.AlertLabels{AlertType: statuspagetypes.PartialOutage},
+				incident: &cloudmonitoring.MonitoringIncident{
+					IncidentID: "another-incident-id",
+					State:      "closed",
+				},
+			},
+			wantStatus: statuspagetypes.DegradedPerformance,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appState := &state.State{}
+			appState.Seed(tt.args.appStateSeed)
+			if tt.stateModifications != nil {
+				tt.stateModifications(appState)
+			}
+			statuspageClient := statuspageapi.Client(tt.args.config)
+			httpmock.ActivateNonDefault(statuspageClient.GetClient())
+			statuspagemocks.ConfigureComponentMock(tt.args.config, tt.args.mockState)
+			callback := StatusUpdater(tt.args.config, appState, statuspageClient)
+			if err := callback(tt.resultArgs.componentName, tt.resultArgs.labels, tt.resultArgs.incident); (err != nil) != tt.wantErr {
+				t.Errorf("callback error %v", err)
+				return
+			}
+			err := appState.UseComponent(tt.resultArgs.componentName, func(c *state.ComponentState) error {
+				// Check that the status got updated in the in-memory state
+				if c.GetDesiredStatus() != tt.wantStatus {
+					t.Errorf("%s status in-memory was %s, wanted %s",
+						tt.resultArgs.componentName,
+						c.GetDesiredStatus().ToString(),
+						tt.wantStatus.ToString())
+				}
+				// Check that the status got updated in the API mock's state
+				if tt.args.mockState[c.GetID()].Status != tt.wantStatus.ToSnakeCase() {
+					t.Errorf("%s status in mock was %s, wanted %s",
+						tt.resultArgs.componentName,
+						tt.args.mockState[c.GetID()].Status,
+						tt.wantStatus.ToSnakeCase())
+				}
+				return nil
+			})
+			if err != nil {
+				t.Errorf("unexpected UseComponent error %v", err)
+				return
+			}
+		})
+	}
+}

--- a/internal/statuspage/statuspageapi/component_api.go
+++ b/internal/statuspage/statuspageapi/component_api.go
@@ -37,18 +37,6 @@ func PostComponent(client *resty.Client, pageID string, component statuspagetype
 	return resp.Result().(*statuspagetypes.Component), nil
 }
 
-// PatchComponent updates an existing component on the remote page by the component's ID, not name
-func PatchComponent(client *resty.Client, pageID string, componentID string, component statuspagetypes.Component) (*statuspagetypes.Component, error) {
-	resp, err := client.R().
-		SetResult(statuspagetypes.Component{}).
-		SetBody(map[string]interface{}{"component": component.ToRequest()}).
-		Patch(fmt.Sprintf("/pages/%s/components/%s", pageID, componentID))
-	if err = shared.CheckResponse(resp, err); err != nil {
-		return nil, err
-	}
-	return resp.Result().(*statuspagetypes.Component), nil
-}
-
 // DeleteComponent deletes an existing component on the remote page by the component's ID, not name
 func DeleteComponent(client *resty.Client, pageID string, componentID string) error {
 	resp, err := client.R().
@@ -57,4 +45,25 @@ func DeleteComponent(client *resty.Client, pageID string, componentID string) er
 		return err
 	}
 	return nil
+}
+
+// PatchComponent updates an existing component on the remote page by the component's ID, not name
+func PatchComponent(client *resty.Client, pageID string, componentID string, component statuspagetypes.Component) (*statuspagetypes.Component, error) {
+	return patchHelper(client, pageID, componentID, map[string]interface{}{"component": component.ToRequest()})
+}
+
+// PatchComponentStatus updates an existing component's status only
+func PatchComponentStatus(client *resty.Client, pageID string, componentID string, newStatus statuspagetypes.Status) (*statuspagetypes.Component, error) {
+	return patchHelper(client, pageID, componentID, map[string]interface{}{"component": map[string]string{"status": newStatus.ToSnakeCase()}})
+}
+
+func patchHelper(client *resty.Client, pageID string, componentID string, body map[string]interface{}) (*statuspagetypes.Component, error) {
+	resp, err := client.R().
+		SetResult(statuspagetypes.Component{}).
+		SetBody(body).
+		Patch(fmt.Sprintf("/pages/%s/components/%s", pageID, componentID))
+	if err = shared.CheckResponse(resp, err); err != nil {
+		return nil, err
+	}
+	return resp.Result().(*statuspagetypes.Component), nil
 }

--- a/internal/statuspage/statuspagemocks/component_api_mock.go
+++ b/internal/statuspage/statuspagemocks/component_api_mock.go
@@ -22,7 +22,7 @@ func ConfigureComponentMock(config *configuration.Config, components map[string]
 		component.PageID = pageID
 		components[id] = component
 	}
-	httpmock.RegisterResponder("GET", fmt.Sprintf(`=~^%s/pages/(\w+)/components`, apiRoot),
+	httpmock.RegisterResponder("GET", fmt.Sprintf(`=~^%s/pages/([^/]+)/components`, apiRoot),
 		func(request *http.Request) (*http.Response, error) {
 			if pageNotFound := validatePageID(pageID, request); pageNotFound != nil {
 				return pageNotFound, nil
@@ -37,7 +37,7 @@ func ConfigureComponentMock(config *configuration.Config, components map[string]
 			}
 			return resp, nil
 		})
-	httpmock.RegisterResponder("POST", fmt.Sprintf(`=~^%s/pages/(\w+)/components`, apiRoot),
+	httpmock.RegisterResponder("POST", fmt.Sprintf(`=~^%s/pages/([^/]+)/components`, apiRoot),
 		func(request *http.Request) (*http.Response, error) {
 			if pageNotFound := validatePageID(pageID, request); pageNotFound != nil {
 				return pageNotFound, nil
@@ -56,7 +56,7 @@ func ConfigureComponentMock(config *configuration.Config, components map[string]
 			}
 			return resp, nil
 		})
-	httpmock.RegisterResponder("PATCH", fmt.Sprintf(`=~^%s/pages/(\w+)/components/(\w+)`, apiRoot),
+	httpmock.RegisterResponder("PATCH", fmt.Sprintf(`=~^%s/pages/([^/]+)/components/([^/]+)`, apiRoot),
 		func(request *http.Request) (*http.Response, error) {
 			if pageNotFound := validatePageID(pageID, request); pageNotFound != nil {
 				return pageNotFound, nil
@@ -87,7 +87,7 @@ func ConfigureComponentMock(config *configuration.Config, components map[string]
 			}
 			return resp, nil
 		})
-	httpmock.RegisterResponder("DELETE", fmt.Sprintf(`=~^%s/pages/(\w+)/components/(\w+)`, apiRoot),
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf(`=~^%s/pages/([^/]+)/components/([^/]+)`, apiRoot),
 		func(request *http.Request) (*http.Response, error) {
 			if pageNotFound := validatePageID(pageID, request); pageNotFound != nil {
 				return pageNotFound, nil

--- a/internal/statuspage/statuspagemocks/component_api_mock.go
+++ b/internal/statuspage/statuspagemocks/component_api_mock.go
@@ -70,8 +70,10 @@ func ConfigureComponentMock(config *configuration.Config, components map[string]
 			}
 			existingComponent := components[httpmock.MustGetSubmatch(request, 2)]
 			// mimic Statuspage's more flexible json behavior as best we can
+			if incomingBody.Component.Name != "" {
+				existingComponent.Name = incomingBody.Component.Name
+			}
 			existingComponent.Description = incomingBody.Component.Description
-			existingComponent.Name = incomingBody.Component.Name
 			existingComponent.OnlyShowIfDegraded = incomingBody.Component.OnlyShowIfDegraded
 			existingComponent.Showcase = incomingBody.Component.Showcase
 			existingComponent.StartDate = incomingBody.Component.StartDate

--- a/internal/statuspage/statuspagetypes/status.go
+++ b/internal/statuspage/statuspagetypes/status.go
@@ -1,6 +1,8 @@
 package statuspagetypes
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Status represents the various component states understood by Statuspage.io
 type Status int
@@ -30,6 +32,22 @@ func (s Status) ToString() string {
 	return fmt.Sprintf("Invalid Status %d", s)
 }
 
+func (s Status) ToSnakeCase() string {
+	switch s {
+	case Operational:
+		return "operational"
+	case DegradedPerformance:
+		return "degraded_performance"
+	case PartialOutage:
+		return "partial_outage"
+	case MajorOutage:
+		return "major_outage"
+	case UnderMaintenance:
+		return "under_maintenance"
+	}
+	return fmt.Sprintf("invalid_status_%d", s)
+}
+
 func StatusFromKebabCase(kebabCaseString string) (Status, error) {
 	switch kebabCaseString {
 	case "operational":
@@ -44,4 +62,14 @@ func StatusFromKebabCase(kebabCaseString string) (Status, error) {
 		return UnderMaintenance, nil
 	}
 	return -1, fmt.Errorf("%s cannot be parsed to a Status", kebabCaseString)
+}
+
+// WorstWith (ab)uses the fact that iota increments per field, so a higher int value
+// is further down the list
+func (s Status) WorstWith(other Status) Status {
+	if s < other {
+		return other
+	} else {
+		return s
+	}
 }

--- a/internal/statuspage/statuspagetypes/status_test.go
+++ b/internal/statuspage/statuspagetypes/status_test.go
@@ -48,6 +48,52 @@ func TestStatus_ToString(t *testing.T) {
 	}
 }
 
+func TestStatus_ToSnakeCase(t *testing.T) {
+	tests := []struct {
+		name string
+		s    Status
+		want string
+	}{
+		{
+			name: "Operational output",
+			s:    Operational,
+			want: "operational",
+		},
+		{
+			name: "DegradedPerformance output",
+			s:    DegradedPerformance,
+			want: "degraded_performance",
+		},
+		{
+			name: "PartialOutage output",
+			s:    PartialOutage,
+			want: "partial_outage",
+		},
+		{
+			name: "MajorOutage output",
+			s:    MajorOutage,
+			want: "major_outage",
+		},
+		{
+			name: "UnderMaintenance output",
+			s:    UnderMaintenance,
+			want: "under_maintenance",
+		},
+		{
+			name: "Invalid status output",
+			s:    -1,
+			want: "invalid_status_-1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.s.ToSnakeCase(); got != tt.want {
+				t.Errorf("ToSnakeCase() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestStatusFromKebabCase(t *testing.T) {
 	type args struct {
 		kebabCaseString string
@@ -99,6 +145,50 @@ func TestStatusFromKebabCase(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("StatusFromKebabCase() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatus_WorstWith(t *testing.T) {
+	type args struct {
+		other Status
+	}
+	tests := []struct {
+		name string
+		s    Status
+		args args
+		want Status
+	}{
+		{
+			name: "Same",
+			s:    MajorOutage,
+			args: args{other: MajorOutage},
+			want: MajorOutage,
+		},
+		{
+			name: "Self worst",
+			s:    MajorOutage,
+			args: args{other: PartialOutage},
+			want: MajorOutage,
+		},
+		{
+			name: "Other worst",
+			s:    Operational,
+			args: args{other: DegradedPerformance},
+			want: DegradedPerformance,
+		},
+		{
+			name: "Maintenance takes precedence",
+			s:    UnderMaintenance,
+			args: args{other: MajorOutage},
+			want: UnderMaintenance,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.s.WorstWith(tt.args.other); got != tt.want {
+				t.Errorf("WorstWith() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,4 @@
 package version
 
+// BuildVersion is mutated at execution time, see main.go for more information
 var BuildVersion = "unknown"


### PR DESCRIPTION
**Most of the added lines here are tests, I'm sorry for the huge diff**

The main things to look at:
- serve.go now passes a callback down to the pubsub.ReceiveMessages function ([here](https://github.com/broadinstitute/revere/blob/DDO-1647-revere-internal-state/cmd/serve.go#L75))
- receive_messages.go runs that callback for every component that a message matches against ([here](https://github.com/broadinstitute/revere/blob/DDO-1647-revere-internal-state/internal/pubsub/receive_messages.go#L43))
- That callback itself is primarily statuspage-related, so it is defined in the statuspage package, in stateful_update_status.go ([here](https://github.com/broadinstitute/revere/blob/DDO-1647-revere-internal-state/internal/statuspage/stateful_update_status.go)). Why is it a callback in the first place? So we can test it seperate from pubsub and so the pubsub code doesn't need to be tightly coupled to the statuspage code.
- That callback uses a "hook" on the new state.State object. I did my best to explain the behavior and purpose of this in the comments