### PR TITLE
[PF-1761] Bump bumper GHA to 0.0.6

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }}
 
       - name: Bump the tag to a new version
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.3
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
         id: tag
         env:
           DEFAULT_BUMP: patch

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
           WITH_V: true
 
       - name: Auth to GCP
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: '345.0.0'
           service_account_email: ${{ secrets.GCP_PUBLISH_EMAIL }}


### PR DESCRIPTION
Bumber is broken with this error “fatal: unsafe repository ('/github/workspace' is owned by someone else)“

It is related with [`fatal: unsafe repository (REPO is owned by someone else)` with ubuntu 20.04 container · Issue #760 · actions/checkout](https://github.com/actions/checkout/issues/760) 

bumber 0.0.6 fix the issue.